### PR TITLE
Fj 2024 lesson 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# KudaGo CRUD API with Logging
+
+This project implements a simple Spring Boot application that provides RESTful APIs for managing categories and locations, leveraging the data from the KudaGo API. It includes logging for method execution time and initialization processes.
+
+## Features
+
+- CRUD operations for two entities:
+  - **Categories**
+    - GET all categories: `/api/v1/places/categories`
+    - GET a category by ID: `/api/v1/places/categories/{id}`
+    - POST a new category: `/api/v1/places/categories`
+    - PUT to update a category by ID: `/api/v1/places/categories/{id}`
+    - DELETE a category by ID: `/api/v1/places/categories/{id}`
+  
+  - **Locations**
+    - GET all locations: `/api/v1/locations`
+    - GET a location by slug: `/api/v1/locations/{slug}`
+    - POST a new location: `/api/v1/locations`
+    - PUT to update a location by slug: `/api/v1/locations/{slug}`
+    - DELETE a location by slug: `/api/v1/locations/{slug}`
+
+- Logging of method execution times using a custom annotation.
+- Automatic initialization of data sources by querying the [KudaGo API](https://docs.kudago.com/api/#) on application startup.
+
+## Requirements
+
+- Java 21
+- Gradle
+
+## Setup
+
+To run the application, follow these steps:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/your-username/your-repo-name.git
+   cd your-repo-name
+   ```
+2. Build the application:
+   ```bash
+   ./gradlew build
+   ```
+3. Run the application:
+   ```bash
+   ./gradlew bootRun
+   ```

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	// LOGS
 	implementation 'org.slf4j:slf4j-api:2.0.0'
 	implementation 'ch.qos.logback:logback-classic:1.4.12'
+
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+	testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,6 @@ java {
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
@@ -28,7 +22,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.aspectj:aspectjweaver'
@@ -37,8 +30,6 @@ dependencies {
 	implementation 'org.slf4j:slf4j-api:2.0.0'
 	implementation 'ch.qos.logback:logback-classic:1.4.12'
 
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 	testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'org.aspectj:aspectjweaver'
+
+	// LOGS
+	implementation 'org.slf4j:slf4j-api:2.0.0'
+	implementation 'ch.qos.logback:logback-classic:1.4.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fin/spr/Application.java
+++ b/src/main/java/com/fin/spr/Application.java
@@ -2,12 +2,40 @@ package com.fin.spr;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
+/**
+ * The {@code Application} class serves as the entry point for the Spring Boot application.
+ * It is annotated with {@link SpringBootApplication}, which enables auto-configuration,
+ * component scanning, and allows for the configuration of Spring beans.
+ *
+ * <p>
+ * This class also enables AspectJ auto-proxying with the {@link EnableAspectJAutoProxy}
+ * annotation, allowing the use of aspects for cross-cutting concerns such as logging and
+ * transaction management.
+ * </p>
+ *
+ * <p>
+ * The main method is the starting point of the application, which launches the Spring
+ * application context.
+ * </p>
+ *
+ * @see SpringBootApplication
+ * @see EnableAspectJAutoProxy
+ *
+ * @author Alexander Garifullin
+ * @version 1.0
+ */
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class Application {
 
+	/**
+	 * The main method, which serves as the entry point for the Spring Boot application.
+	 *
+	 * @param args Command-line arguments passed to the application
+	 */
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
-
 }

--- a/src/main/java/com/fin/spr/annotations/LogExecutionTime.java
+++ b/src/main/java/com/fin/spr/annotations/LogExecutionTime.java
@@ -1,0 +1,32 @@
+package com.fin.spr.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code LogExecutionTime} annotation is used for logging the execution time
+ * of methods and classes. This annotation can be applied to both methods and classes.
+ *
+ * <p>
+ * When applied to a method, the execution time of that method will be captured
+ * and recorded in the log. If the annotation is applied to a class, all methods
+ * within that class will log their execution time.
+ * </p>
+ *
+ * <p>
+ * The annotation is retained at runtime, allowing it to be utilized in
+ * aspect-oriented programming (AOP) mechanisms, such as Spring AOP.
+ * </p>
+ *
+ * @see org.aspectj.lang.annotation.Aspect
+ * @see org.aspectj.lang.ProceedingJoinPoint
+ *
+ * @author Alexander Garifullin
+ * @version 1.0
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}

--- a/src/main/java/com/fin/spr/aspects/ExecutionTimeLogger.java
+++ b/src/main/java/com/fin/spr/aspects/ExecutionTimeLogger.java
@@ -1,0 +1,65 @@
+package com.fin.spr.aspects;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * The {@code ExecutionTimeLogger} class is an aspect that logs the execution time
+ * of methods annotated with {@link com.fin.spr.annotations.LogExecutionTime}.
+ * This class uses Aspect-Oriented Programming (AOP) to intercept method calls
+ * and record their execution duration.
+ *
+ * <p>
+ * The {@code logExecutionTime} method is invoked around the execution of the
+ * target method. It calculates the time taken to execute the method and logs
+ * this information along with the method's name and its declaring class.
+ * </p>
+ *
+ * <p>
+ * If any exception occurs during the execution of the method, it is logged as an error.
+ * </p>
+ *
+ * <p>
+ * This class is marked with the {@code @Component} annotation, allowing Spring to
+ * detect and manage it as a bean.
+ * </p>
+ *
+ * @see com.fin.spr.annotations.LogExecutionTime
+ * @see org.aspectj.lang.annotation.Aspect
+ *
+ * @author Alexander Garifullin
+ * @version 1.0
+ */
+@Aspect
+@Component
+public class ExecutionTimeLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExecutionTimeLogger.class);
+
+    @Around("@annotation(com.fin.spr.annotations.LogExecutionTime) || @within(com.fin.spr.annotations.LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) {
+        long start = System.currentTimeMillis();
+        Object proceed = null;
+
+
+        String methodName = joinPoint.getSignature().getName();
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+
+        logger.info("Method {} of class {} started", methodName, className);
+
+        try {
+            proceed = joinPoint.proceed();
+        } catch (Throwable throwable) {
+            logger.error("Error during method execution: {}", throwable.getMessage());
+        } finally {
+            long executionTime = System.currentTimeMillis() - start;
+            logger.info("Method {} of class {} finished. Execution time: {} ms", methodName, className, executionTime);
+        }
+        return proceed;
+    }
+}

--- a/src/main/java/com/fin/spr/config/AppConfig.java
+++ b/src/main/java/com/fin/spr/config/AppConfig.java
@@ -1,0 +1,23 @@
+package com.fin.spr.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The {@code AppConfig} class provides the configuration for the application.
+ * It contains bean definitions that are used throughout the application.
+ */
+@Configuration
+public class AppConfig {
+
+    /**
+     * Creates and returns a new instance of {@link RestTemplate}.
+     *
+     * @return a {@link RestTemplate} instance used for making HTTP requests
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/fin/spr/config/AppConfig.java
+++ b/src/main/java/com/fin/spr/config/AppConfig.java
@@ -2,7 +2,7 @@ package com.fin.spr.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 /**
  * The {@code AppConfig} class provides the configuration for the application.
@@ -12,12 +12,12 @@ import org.springframework.web.client.RestTemplate;
 public class AppConfig {
 
     /**
-     * Creates and returns a new instance of {@link RestTemplate}.
+     * Creates and returns a new instance of {@link RestClient}.
      *
-     * @return a {@link RestTemplate} instance used for making HTTP requests
+     * @return a {@link RestClient} instance used for making HTTP requests
      */
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestClient restClient() {
+        return  RestClient.create();
     }
 }

--- a/src/main/java/com/fin/spr/config/StorageConfig.java
+++ b/src/main/java/com/fin/spr/config/StorageConfig.java
@@ -1,0 +1,40 @@
+package com.fin.spr.config;
+
+import com.fin.spr.models.Category;
+import com.fin.spr.models.Location;
+import com.fin.spr.storage.InMemoryStorage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The {@code StorageConfig} class provides configuration for in-memory storage
+ * beans in the application. It defines the storage for {@link Category} and
+ * {@link Location} entities.
+ */
+@Configuration
+public class StorageConfig {
+
+    /**
+     * Creates and returns a new instance of {@link InMemoryStorage} for
+     * managing {@link Category} entities.
+     *
+     * @return an {@link InMemoryStorage} instance for {@link Category} with
+     *         {@link Integer} as the identifier type
+     */
+    @Bean
+    public InMemoryStorage<Category, Integer> categoryStorage() {
+        return new InMemoryStorage<>();
+    }
+
+    /**
+     * Creates and returns a new instance of {@link InMemoryStorage} for
+     * managing {@link Location} entities.
+     *
+     * @return an {@link InMemoryStorage} instance for {@link Location} with
+     *         {@link String} as the identifier type
+     */
+    @Bean
+    public InMemoryStorage<Location, String> locationStorage() {
+        return new InMemoryStorage<>();
+    }
+}

--- a/src/main/java/com/fin/spr/controllers/CategoryController.java
+++ b/src/main/java/com/fin/spr/controllers/CategoryController.java
@@ -61,7 +61,7 @@ public class CategoryController implements ICategoryController {
     @Override
     public ResponseEntity<Category> createCategory(@RequestBody Category category) {
         try {
-            categoryService.createCategory(category.getId(), category);
+            categoryService.createCategory(category);
             return ResponseEntity.status(201).body(category);
         } catch (EntityAlreadyExistsException e) {
             return ResponseEntity.status(409).body(null);

--- a/src/main/java/com/fin/spr/controllers/CategoryController.java
+++ b/src/main/java/com/fin/spr/controllers/CategoryController.java
@@ -6,6 +6,7 @@ import com.fin.spr.interfaces.ICategoryController;
 import com.fin.spr.interfaces.ICategoryService;
 import com.fin.spr.models.Category;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,13 +28,14 @@ public class CategoryController implements ICategoryController {
     /**
      * Retrieves all categories.
      *
-     * @return a ResponseEntity containing a list of all categories and an HTTP status code.
+     * @return a list of all categories and an HTTP status code.
      */
     @GetMapping
     @Override
-    public ResponseEntity<List<Category>> getAllCategories() {
+    @ResponseStatus(HttpStatus.OK)
+    public List<Category> getAllCategories() {
         List<Category> categories = categoryService.getAllCategories();
-        return ResponseEntity.ok(categories);
+        return categories;
     }
 
     /**

--- a/src/main/java/com/fin/spr/controllers/CategoryController.java
+++ b/src/main/java/com/fin/spr/controllers/CategoryController.java
@@ -1,0 +1,98 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.annotations.LogExecutionTime;
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.interfaces.ICategoryController;
+import com.fin.spr.interfaces.ICategoryService;
+import com.fin.spr.models.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * REST controller for managing categories in the application.
+ * This controller provides endpoints to perform CRUD operations on categories.
+ */
+@RestController
+@RequestMapping("/api/v1/places/categories")
+@LogExecutionTime
+public class CategoryController implements ICategoryController {
+
+    @Autowired
+    private ICategoryService categoryService;
+
+    /**
+     * Retrieves all categories.
+     *
+     * @return a ResponseEntity containing a list of all categories and an HTTP status code.
+     */
+    @GetMapping
+    @Override
+    public ResponseEntity<List<Category>> getAllCategories() {
+        List<Category> categories = categoryService.getAllCategories();
+        return ResponseEntity.ok(categories);
+    }
+
+    /**
+     * Retrieves a category by its ID.
+     *
+     * @param id the ID of the category to retrieve.
+     * @return a ResponseEntity containing the found category or an HTTP 404 status code if not found.
+     */
+    @GetMapping("/{id}")
+    @Override
+    public ResponseEntity<Category> getCategoryById(@PathVariable Integer id) {
+        Optional<Category> category = categoryService.getCategoryById(id);
+        return category.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates a new category.
+     *
+     * @param category the category to create.
+     * @return a ResponseEntity containing the created category and an HTTP status code.
+     *         Returns HTTP 409 if the category already exists.
+     */
+    @PostMapping
+    @Override
+    public ResponseEntity<Category> createCategory(@RequestBody Category category) {
+        try {
+            categoryService.createCategory(category.getId(), category);
+            return ResponseEntity.status(201).body(category);
+        } catch (EntityAlreadyExistsException e) {
+            return ResponseEntity.status(409).body(null);
+        }
+    }
+
+    /**
+     * Updates an existing category.
+     *
+     * @param id the ID of the category to update.
+     * @param category the updated category data.
+     * @return a ResponseEntity containing the updated category or an HTTP 404 status code if not found.
+     */
+    @PutMapping("/{id}")
+    @Override
+    public ResponseEntity<Category> updateCategory(@PathVariable Integer id, @RequestBody Category category) {
+        boolean updated = categoryService.updateCategory(id, category);
+        return updated ? ResponseEntity.ok(category) : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * Deletes a category by its ID.
+     *
+     * @param id the ID of the category to delete.
+     * @return a ResponseEntity with an HTTP status code indicating the result of the operation.
+     *         Returns HTTP 204 if the category was deleted, or HTTP 404 if not found.
+     */
+    @DeleteMapping("/{id}")
+    @Override
+    public ResponseEntity<Void> deleteCategory(@PathVariable Integer id) {
+        boolean deleted = categoryService.deleteCategory(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/fin/spr/controllers/LocationController.java
+++ b/src/main/java/com/fin/spr/controllers/LocationController.java
@@ -1,0 +1,97 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.annotations.LogExecutionTime;
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.interfaces.ILocationController;
+import com.fin.spr.interfaces.ILocationService;
+import com.fin.spr.models.Location;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code LocationController} class handles HTTP requests related to {@link Location} entities.
+ * It implements the {@link ILocationController} interface and uses the {@link ILocationService}
+ * to perform CRUD operations on locations.
+ */
+@RestController
+@RequestMapping("/api/v1/locations")
+@LogExecutionTime
+public class LocationController implements ILocationController {
+
+    @Autowired
+    private ILocationService locationService;
+
+    /**
+     * Retrieves all locations stored in the system.
+     *
+     * @return a {@link ResponseEntity} containing a list of all {@link Location} entities
+     */
+    @GetMapping
+    @Override
+    public ResponseEntity<List<Location>> getAllLocations() {
+        List<Location> locations = locationService.getAllLocations();
+        return ResponseEntity.ok(locations);
+    }
+
+    /**
+     * Retrieves a location by its unique slug.
+     *
+     * @param slug the unique slug of the location to retrieve
+     * @return a {@link ResponseEntity} containing the found {@link Location}, or a not found response if not found
+     */
+    @GetMapping("/{slug}")
+    @Override
+    public ResponseEntity<Location> getLocationBySlug(@PathVariable String slug) {
+        Optional<Location> location = locationService.getLocationBySlug(slug);
+        return location.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Creates a new location in the system.
+     *
+     * @param location the {@link Location} entity to be created
+     * @return a {@link ResponseEntity} containing the created {@link Location}, with a status of 201 (Created)
+     */
+    @PostMapping
+    @Override
+    public ResponseEntity<Location> createLocation(@RequestBody Location location) {
+        try {
+            locationService.createLocation(location);
+            return ResponseEntity.status(201).body(location);
+        } catch (EntityAlreadyExistsException e) {
+            return ResponseEntity.status(409).body(null);
+        }
+    }
+
+    /**
+     * Updates an existing location in the system.
+     *
+     * @param slug     the unique slug of the location to update
+     * @param location the updated {@link Location} entity
+     * @return a {@link ResponseEntity} indicating the result of the update operation
+     */
+    @PutMapping("/{slug}")
+    @Override
+    public ResponseEntity<Location> updateLocation(@PathVariable String slug, @RequestBody Location location) {
+        boolean updated = locationService.updateLocation(slug, location);
+        return updated ? ResponseEntity.ok(location) : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * Deletes a location from the system by its unique slug.
+     *
+     * @param slug the unique slug of the location to be deleted
+     * @return a {@link ResponseEntity} indicating the result of the deletion operation
+     */
+    @DeleteMapping("/{slug}")
+    @Override
+    public ResponseEntity<Void> deleteLocation(@PathVariable String slug) {
+        boolean deleted = locationService.deleteLocation(slug);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/fin/spr/controllers/LocationController.java
+++ b/src/main/java/com/fin/spr/controllers/LocationController.java
@@ -6,6 +6,7 @@ import com.fin.spr.interfaces.ILocationController;
 import com.fin.spr.interfaces.ILocationService;
 import com.fin.spr.models.Location;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,13 +29,13 @@ public class LocationController implements ILocationController {
     /**
      * Retrieves all locations stored in the system.
      *
-     * @return a {@link ResponseEntity} containing a list of all {@link Location} entities
+     * @return a list of all {@link Location} entities
      */
     @GetMapping
     @Override
-    public ResponseEntity<List<Location>> getAllLocations() {
-        List<Location> locations = locationService.getAllLocations();
-        return ResponseEntity.ok(locations);
+    @ResponseStatus(HttpStatus.OK)
+    public List<Location> getAllLocations() {
+        return locationService.getAllLocations();
     }
 
     /**

--- a/src/main/java/com/fin/spr/exceptions/EntityAlreadyExistsException.java
+++ b/src/main/java/com/fin/spr/exceptions/EntityAlreadyExistsException.java
@@ -1,0 +1,18 @@
+package com.fin.spr.exceptions;
+
+/**
+ * The {@code EntityAlreadyExistsException} class is a custom runtime exception
+ * that is thrown when an attempt is made to create an entity that already exists
+ * in the storage.
+ */
+public class EntityAlreadyExistsException extends RuntimeException {
+
+    /**
+     * Constructs a new {@code EntityAlreadyExistsException} with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
+    public EntityAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fin/spr/interfaces/ICategoryController.java
+++ b/src/main/java/com/fin/spr/interfaces/ICategoryController.java
@@ -1,0 +1,53 @@
+package com.fin.spr.interfaces;
+
+import com.fin.spr.models.Category;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+/**
+ * The {@code ICategoryController} interface defines the contract for managing category-related operations
+ * in the application. It provides methods for performing CRUD operations on {@link Category} entities.
+ */
+public interface ICategoryController {
+
+    /**
+     * Retrieves a list of all categories.
+     *
+     * @return a {@link ResponseEntity} containing a list of {@link Category} entities
+     */
+    ResponseEntity<List<Category>> getAllCategories();
+
+    /**
+     * Retrieves a category by its identifier.
+     *
+     * @param id the identifier of the category to retrieve
+     * @return a {@link ResponseEntity} containing the found {@link Category}, or an error response if not found
+     */
+    ResponseEntity<Category> getCategoryById(Integer  id);
+
+    /**
+     * Creates a new category.
+     *
+     * @param category the {@link Category} entity to be created
+     * @return a {@link ResponseEntity} containing the created {@link Category}
+     */
+    ResponseEntity<Category> createCategory(Category category);
+
+    /**
+     * Updates an existing category by its identifier.
+     *
+     * @param id       the identifier of the category to update
+     * @param category the updated {@link Category} entity
+     * @return a {@link ResponseEntity} containing the updated {@link Category}, or an error response if not found
+     */
+    ResponseEntity<Category> updateCategory(Integer  id, Category category);
+
+    /**
+     * Deletes a category by its identifier.
+     *
+     * @param id the identifier of the category to be deleted
+     * @return a {@link ResponseEntity} indicating the outcome of the deletion operation
+     */
+    ResponseEntity<Void> deleteCategory(Integer  id);
+}

--- a/src/main/java/com/fin/spr/interfaces/ICategoryController.java
+++ b/src/main/java/com/fin/spr/interfaces/ICategoryController.java
@@ -14,9 +14,9 @@ public interface ICategoryController {
     /**
      * Retrieves a list of all categories.
      *
-     * @return a {@link ResponseEntity} containing a list of {@link Category} entities
+     * @return a list of {@link Category} entities
      */
-    ResponseEntity<List<Category>> getAllCategories();
+    List<Category> getAllCategories();
 
     /**
      * Retrieves a category by its identifier.

--- a/src/main/java/com/fin/spr/interfaces/ICategoryService.java
+++ b/src/main/java/com/fin/spr/interfaces/ICategoryService.java
@@ -30,10 +30,9 @@ public interface ICategoryService {
     /**
      * Creates a new category with the specified identifier.
      *
-     * @param id       the identifier for the new category
      * @param category the {@link Category} entity to be created
      */
-    void createCategory(Integer id, Category category);
+    void createCategory(Category category);
 
     /**
      * Updates an existing category identified by its identifier.

--- a/src/main/java/com/fin/spr/interfaces/ICategoryService.java
+++ b/src/main/java/com/fin/spr/interfaces/ICategoryService.java
@@ -1,0 +1,54 @@
+package com.fin.spr.interfaces;
+
+import com.fin.spr.models.Category;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code ICategoryService} interface defines the contract for services
+ * managing {@link Category} entities. It provides methods to perform
+ * operations such as retrieving, creating, updating, and deleting categories.
+ */
+public interface ICategoryService {
+
+    /**
+     * Retrieves a list of all categories.
+     *
+     * @return a {@link List} containing all {@link Category} entities
+     */
+    List<Category> getAllCategories();
+
+    /**
+     * Retrieves a category by its identifier.
+     *
+     * @param id the identifier of the category to retrieve
+     * @return an {@link Optional} containing the found {@link Category}, or empty if not found
+     */
+    Optional<Category> getCategoryById(Integer id);
+
+    /**
+     * Creates a new category with the specified identifier.
+     *
+     * @param id       the identifier for the new category
+     * @param category the {@link Category} entity to be created
+     */
+    void createCategory(Integer id, Category category);
+
+    /**
+     * Updates an existing category identified by its identifier.
+     *
+     * @param id       the identifier of the category to update
+     * @param category the updated {@link Category} entity
+     * @return true if the update was successful, false if the category was not found
+     */
+    boolean updateCategory(Integer id, Category category);
+
+    /**
+     * Deletes a category identified by its identifier.
+     *
+     * @param id the identifier of the category to be deleted
+     * @return true if the deletion was successful, false if the category was not found
+     */
+    boolean deleteCategory(Integer id);
+}

--- a/src/main/java/com/fin/spr/interfaces/ILocationController.java
+++ b/src/main/java/com/fin/spr/interfaces/ILocationController.java
@@ -14,9 +14,9 @@ public interface ILocationController {
     /**
      * Retrieves a list of all locations.
      *
-     * @return a {@link ResponseEntity} containing a list of {@link Location} entities
+     * @return a list of {@link Location} entities
      */
-    ResponseEntity<List<Location>> getAllLocations();
+    List<Location> getAllLocations();
 
     /**
      * Retrieves a location by its unique slug.

--- a/src/main/java/com/fin/spr/interfaces/ILocationController.java
+++ b/src/main/java/com/fin/spr/interfaces/ILocationController.java
@@ -1,0 +1,53 @@
+package com.fin.spr.interfaces;
+
+import com.fin.spr.models.Location;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+/**
+ * The {@code ILocationController} interface defines the contract for managing location-related operations
+ * in the application. It provides methods for performing CRUD operations on {@link Location} entities.
+ */
+public interface ILocationController {
+
+    /**
+     * Retrieves a list of all locations.
+     *
+     * @return a {@link ResponseEntity} containing a list of {@link Location} entities
+     */
+    ResponseEntity<List<Location>> getAllLocations();
+
+    /**
+     * Retrieves a location by its unique slug.
+     *
+     * @param slug the unique slug of the location to retrieve
+     * @return a {@link ResponseEntity} containing the found {@link Location}, or an error response if not found
+     */
+    ResponseEntity<Location> getLocationBySlug(String slug);
+
+    /**
+     * Creates a new location.
+     *
+     * @param location the {@link Location} entity to be created
+     * @return a {@link ResponseEntity} containing the created {@link Location}
+     */
+    ResponseEntity<Location> createLocation(Location location);
+
+    /**
+     * Updates an existing location by its unique slug.
+     *
+     * @param slug     the unique slug of the location to update
+     * @param location the updated {@link Location} entity
+     * @return a {@link ResponseEntity} containing the updated {@link Location}, or an error response if not found
+     */
+    ResponseEntity<Location> updateLocation(String slug, Location location);
+
+    /**
+     * Deletes a location by its unique slug.
+     *
+     * @param slug the unique slug of the location to be deleted
+     * @return a {@link ResponseEntity} indicating the outcome of the deletion operation
+     */
+    ResponseEntity<Void> deleteLocation(String slug);
+}

--- a/src/main/java/com/fin/spr/interfaces/ILocationService.java
+++ b/src/main/java/com/fin/spr/interfaces/ILocationService.java
@@ -1,0 +1,53 @@
+package com.fin.spr.interfaces;
+
+import com.fin.spr.models.Location;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code ILocationService} interface defines the contract for services
+ * managing {@link Location} entities. It provides methods to perform
+ * operations such as retrieving, creating, updating, and deleting locations.
+ */
+public interface ILocationService {
+
+    /**
+     * Retrieves a list of all locations.
+     *
+     * @return a {@link List} containing all {@link Location} entities
+     */
+    List<Location> getAllLocations();
+
+    /**
+     * Retrieves a location by its unique slug.
+     *
+     * @param slug the unique slug of the location to retrieve
+     * @return an {@link Optional} containing the found {@link Location}, or empty if not found
+     */
+    Optional<Location> getLocationBySlug(String slug);
+
+    /**
+     * Creates a new location.
+     *
+     * @param location the {@link Location} entity to be created
+     */
+    void createLocation(Location location);
+
+    /**
+     * Updates an existing location identified by its unique slug.
+     *
+     * @param slug     the unique slug of the location to update
+     * @param location the updated {@link Location} entity
+     * @return true if the update was successful, false if the location was not found
+     */
+    boolean updateLocation(String slug, Location location);
+
+    /**
+     * Deletes a location identified by its unique slug.
+     *
+     * @param slug the unique slug of the location to be deleted
+     * @return true if the deletion was successful, false if the location was not found
+     */
+    boolean deleteLocation(String slug);
+}

--- a/src/main/java/com/fin/spr/models/Category.java
+++ b/src/main/java/com/fin/spr/models/Category.java
@@ -1,0 +1,27 @@
+package com.fin.spr.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * The {@code Category} class represents a category entity with an identifier,
+ * a slug, and a name. It is used to categorize entities within the application.
+ */
+@Data
+@AllArgsConstructor
+public class Category {
+    /**
+     * The unique identifier for the category.
+     */
+    private int id;
+
+    /**
+     * The slug of the category, used for URL-friendly identification.
+     */
+    private String slug;
+
+    /**
+     * The name of the category.
+     */
+    private String name;
+}

--- a/src/main/java/com/fin/spr/models/Location.java
+++ b/src/main/java/com/fin/spr/models/Location.java
@@ -1,0 +1,22 @@
+package com.fin.spr.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * The {@code Location} class represents a location entity with a slug and a name.
+ * It is used to identify and describe different locations within the application.
+ */
+@Data
+@AllArgsConstructor
+public class Location {
+    /**
+     * The unique slug for the location, used for URL-friendly identification.
+     */
+    private String slug;
+
+    /**
+     * The name of the location.
+     */
+    private String name;
+}

--- a/src/main/java/com/fin/spr/services/CategoryService.java
+++ b/src/main/java/com/fin/spr/services/CategoryService.java
@@ -1,0 +1,77 @@
+package com.fin.spr.services;
+
+import com.fin.spr.interfaces.ICategoryService;
+import com.fin.spr.models.Category;
+import com.fin.spr.storage.InMemoryStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code CategoryService} class provides the implementation of the {@link ICategoryService} interface
+ * for managing categories. It utilizes an in-memory storage solution to perform CRUD operations
+ * on {@link Category} entities.
+ */
+@Service
+public class CategoryService implements ICategoryService {
+
+    @Autowired
+    private InMemoryStorage<Category, Integer> categoryStorage;
+
+    /**
+     * Retrieves a list of all categories stored in the system.
+     *
+     * @return a list of all {@link Category} entities
+     */
+    @Override
+    public List<Category> getAllCategories() {
+        return categoryStorage.getAll();
+    }
+
+    /**
+     * Retrieves a category by its identifier.
+     *
+     * @param id the identifier of the category to retrieve
+     * @return an {@link Optional} containing the found {@link Category}, or empty if not found
+     */
+    @Override
+    public Optional<Category> getCategoryById(Integer id) {
+        return categoryStorage.getById(id);
+    }
+
+    /**
+     * Creates a new category in the storage.
+     *
+     * @param id       the identifier for the new category
+     * @param category the {@link Category} entity to be created
+     */
+    @Override
+    public void createCategory(Integer id, Category category) {
+        categoryStorage.create(id, category);
+    }
+
+    /**
+     * Updates an existing category in the storage.
+     *
+     * @param id       the identifier of the category to update
+     * @param category the updated {@link Category} entity
+     * @return true if the update was successful, false if the category was not found
+     */
+    @Override
+    public boolean updateCategory(Integer id, Category category) {
+        return categoryStorage.update(id, category);
+    }
+
+    /**
+     * Deletes a category from the storage by its identifier.
+     *
+     * @param id the identifier of the category to be deleted
+     * @return true if the deletion was successful, false if the category was not found
+     */
+    @Override
+    public boolean deleteCategory(Integer id) {
+        return categoryStorage.delete(id);
+    }
+}

--- a/src/main/java/com/fin/spr/services/CategoryService.java
+++ b/src/main/java/com/fin/spr/services/CategoryService.java
@@ -44,12 +44,11 @@ public class CategoryService implements ICategoryService {
     /**
      * Creates a new category in the storage.
      *
-     * @param id       the identifier for the new category
      * @param category the {@link Category} entity to be created
      */
     @Override
-    public void createCategory(Integer id, Category category) {
-        categoryStorage.create(id, category);
+    public void createCategory(Category category) {
+        categoryStorage.create(category.getId(), category);
     }
 
     /**

--- a/src/main/java/com/fin/spr/services/KudaGoDataLoader.java
+++ b/src/main/java/com/fin/spr/services/KudaGoDataLoader.java
@@ -1,0 +1,93 @@
+package com.fin.spr.services;
+
+import com.fin.spr.annotations.LogExecutionTime;
+import com.fin.spr.models.Category;
+import com.fin.spr.models.Location;
+import com.fin.spr.storage.InMemoryStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+/**
+ * The {@code KudaGoDataLoader} class is responsible for initializing data
+ * from the KudaGo API into in-memory storage for categories and locations.
+ *
+ * <p>
+ * This class uses the {@link RestTemplate} to make HTTP requests to the KudaGo API
+ * and retrieves categories and locations. The retrieved data is stored in
+ * {@link InMemoryStorage} for further use in the application.
+ * </p>
+ *
+ * <p>
+ * The initialization process is triggered when the application is ready,
+ * and the execution time of the initialization method is logged using
+ * the {@link LogExecutionTime} annotation.
+ * </p>
+ *
+ * <p>
+ * The class is annotated with {@code @Service}, allowing it to be detected
+ * and managed by Spring's dependency injection framework.
+ * </p>
+ *
+ * @see com.fin.spr.models.Category
+ * @see com.fin.spr.models.Location
+ * @see com.fin.spr.storage.InMemoryStorage
+ * @see com.fin.spr.annotations.LogExecutionTime
+ *
+ * @author Alexander Garifullin
+ * @version 1.0
+ */
+@Service
+@LogExecutionTime
+public class KudaGoDataLoader {
+
+    private static final String CATEGORIES_API_URL = "https://kudago.com/public-api/v1.4/place-categories";
+    private static final String LOCATIONS_API_URL = "https://kudago.com/public-api/v1.4/locations";
+    private static final Logger logger = LoggerFactory.getLogger(KudaGoDataLoader.class);
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private InMemoryStorage<Category, Integer> categoryStorage;
+
+    @Autowired
+    private InMemoryStorage<Location, String> locationStorage;
+
+    /**
+     * Initializes data from the KudaGo API and stores it in memory.
+     * This method is invoked when the application is ready, indicated
+     * by the {@link ApplicationReadyEvent}.
+     *
+     * <p>
+     * The method retrieves categories and locations from their respective
+     * API endpoints and stores them in the in-memory storage.
+     * Log messages indicate the progress and completion of the initialization.
+     * </p>
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    @LogExecutionTime
+    public void initData() {
+        logger.info("Starting data initialization from the KudaGo API...");
+
+        Category[] categories = restTemplate.getForObject(CATEGORIES_API_URL, Category[].class);
+        if (categories != null) {
+            Arrays.stream(categories).forEach(category -> categoryStorage.create(category.getId(), category));
+            logger.info("Categories have been successfully initialized.");
+        }
+
+        Location[] locations = restTemplate.getForObject(LOCATIONS_API_URL, Location[].class);
+        if (locations != null) {
+            Arrays.stream(locations).forEach(location -> locationStorage.create(location.getSlug(), location));
+            logger.info("Locations have been successfully initialized.");
+        }
+
+        logger.info("Data initialization completed.");
+    }
+}

--- a/src/main/java/com/fin/spr/services/LocationService.java
+++ b/src/main/java/com/fin/spr/services/LocationService.java
@@ -1,0 +1,76 @@
+package com.fin.spr.services;
+
+import com.fin.spr.interfaces.ILocationService;
+import com.fin.spr.models.Location;
+import com.fin.spr.storage.InMemoryStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code LocationService} class provides the implementation of the {@link ILocationService} interface
+ * for managing locations. It utilizes an in-memory storage solution to perform CRUD operations
+ * on {@link Location} entities.
+ */
+@Service
+public class LocationService implements ILocationService {
+
+    @Autowired
+    private InMemoryStorage<Location, String> locationStorage;
+
+    /**
+     * Retrieves a list of all locations stored in the system.
+     *
+     * @return a list of all {@link Location} entities
+     */
+    @Override
+    public List<Location> getAllLocations() {
+        return locationStorage.getAll();
+    }
+
+    /**
+     * Retrieves a location by its unique slug.
+     *
+     * @param slug the unique slug of the location to retrieve
+     * @return an {@link Optional} containing the found {@link Location}, or empty if not found
+     */
+    @Override
+    public Optional<Location> getLocationBySlug(String slug) {
+        return locationStorage.getById(slug);
+    }
+
+    /**
+     * Creates a new location in the storage.
+     *
+     * @param location the {@link Location} entity to be created
+     */
+    @Override
+    public void createLocation(Location location) {
+        locationStorage.create(location.getSlug(), location);
+    }
+
+    /**
+     * Updates an existing location in the storage.
+     *
+     * @param slug     the unique slug of the location to update
+     * @param location the updated {@link Location} entity
+     * @return true if the update was successful, false if the location was not found
+     */
+    @Override
+    public boolean updateLocation(String slug, Location location) {
+        return locationStorage.update(slug, location);
+    }
+
+    /**
+     * Deletes a location from the storage by its unique slug.
+     *
+     * @param slug the unique slug of the location to be deleted
+     * @return true if the deletion was successful, false if the location was not found
+     */
+    @Override
+    public boolean deleteLocation(String slug) {
+        return locationStorage.delete(slug);
+    }
+}

--- a/src/main/java/com/fin/spr/storage/InMemoryStorage.java
+++ b/src/main/java/com/fin/spr/storage/InMemoryStorage.java
@@ -1,0 +1,87 @@
+package com.fin.spr.storage;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The {@code InMemoryStorage} class provides a thread-safe in-memory storage solution
+ * for managing entities of type {@code T} with a specified identifier type {@code ID}.
+ * It uses a {@link ConcurrentHashMap} for concurrent access and storage operations.
+ *
+ * @param <T> the type of entities to be stored
+ * @param <ID> the type of the identifier for the entities
+ */
+public class InMemoryStorage<T, ID> {
+    private final ConcurrentHashMap<ID, T> storage = new ConcurrentHashMap<>();
+
+    /**
+     * Retrieves all entities stored in memory.
+     *
+     * @return a list containing all stored entities
+     */
+    public List<T> getAll() {
+        return List.copyOf(storage.values());
+    }
+
+    /**
+     * Retrieves an entity by its identifier.
+     *
+     * @param id the identifier of the entity to retrieve
+     * @return an {@link Optional} containing the found entity, or empty if not found
+     */
+    public Optional<T> getById(ID id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    /**
+     * Creates a new entity in the storage.
+     *
+     * @param id     the identifier for the entity
+     * @param entity the entity to be stored
+     * @throws EntityAlreadyExistsException if an entity with the given identifier already exists
+     */
+    public void create(ID id, T entity) {
+        if (storage.containsKey(id)) {
+            throw new EntityAlreadyExistsException(entityAlreadyExistsMsg(id));
+        }
+        storage.put(id, entity);
+    }
+
+    /**
+     * Updates an existing entity in the storage.
+     *
+     * @param id     the identifier of the entity to update
+     * @param entity the updated entity
+     * @return true if the update was successful, false if the entity was not found
+     */
+    public boolean update(ID id, T entity) {
+        if (storage.containsKey(id)) {
+            storage.put(id, entity);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Deletes an entity from the storage by its identifier.
+     *
+     * @param id the identifier of the entity to be deleted
+     * @return true if the deletion was successful, false if the entity was not found
+     */
+    public boolean delete(ID id) {
+        return storage.remove(id) != null;
+    }
+
+    /**
+     * Generates a message indicating that an entity with the specified identifier already exists.
+     *
+     * @param id the identifier of the entity
+     * @return a string message indicating the existence of the entity
+     */
+    private String entityAlreadyExistsMsg(ID id) {
+        return "Entity with ID " + id + " already exists.";
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/java/com/fin/spr/controllers/CategoryControllerIntegrationTest.java
+++ b/src/test/java/com/fin/spr/controllers/CategoryControllerIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.models.Category;
+import com.fin.spr.services.CategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CategoryControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Category testCategory1;
+    private Category testCategory2;
+
+    private static final String BASE_URL = "/api/v1/places/categories";
+
+    @BeforeEach
+    public void setup() {
+        testCategory1 = new Category(1, "museums", "Museums");
+        testCategory2 = new Category(2, "parks", "Parks");
+    }
+
+    @Test
+    public void testGetAllCategories() throws Exception {
+        Mockito.when(categoryService.getAllCategories()).thenReturn(Arrays.asList(testCategory1, testCategory2));
+
+        mockMvc.perform(get(BASE_URL))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].name").value("Museums"))
+                .andExpect(jsonPath("$[1].name").value("Parks"));
+    }
+
+    @Test
+    public void testGetCategoryById_Success() throws Exception {
+        Mockito.when(categoryService.getCategoryById(1)).thenReturn(Optional.of(testCategory1));
+
+        mockMvc.perform(get(BASE_URL + "/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value("Museums"))
+                .andExpect(jsonPath("$.slug").value("museums"));
+    }
+
+    @Test
+    public void testGetCategoryById_NotFound() throws Exception {
+        Mockito.when(categoryService.getCategoryById(99)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(BASE_URL + "/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testCreateCategory_Success() throws Exception {
+        Mockito.doNothing().when(categoryService).createCategory(any(Category.class));
+
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCategory1)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Museums"))
+                .andExpect(jsonPath("$.slug").value("museums"));
+    }
+
+    @Test
+    public void testCreateCategory_Conflict() throws Exception {
+        Mockito.doThrow(new EntityAlreadyExistsException("Category already exists")).when(categoryService).createCategory(any(Category.class));
+
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCategory1)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    public void testUpdateCategory_Success() throws Exception {
+        Mockito.when(categoryService.updateCategory(eq(1), any(Category.class))).thenReturn(true);
+
+        mockMvc.perform(put(BASE_URL + "/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCategory1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Museums"))
+                .andExpect(jsonPath("$.slug").value("museums"));
+    }
+
+    @Test
+    public void testUpdateCategory_NotFound() throws Exception {
+        Mockito.when(categoryService.updateCategory(eq(99), any(Category.class))).thenReturn(false);
+
+        mockMvc.perform(put(BASE_URL + "/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCategory1)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testDeleteCategory_Success() throws Exception {
+        Mockito.when(categoryService.deleteCategory(1)).thenReturn(true);
+
+        mockMvc.perform(delete(BASE_URL + "/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void testDeleteCategory_NotFound() throws Exception {
+        Mockito.when(categoryService.deleteCategory(99)).thenReturn(false);
+
+        mockMvc.perform(delete(BASE_URL + "/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
+++ b/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
@@ -1,0 +1,128 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.interfaces.ICategoryService;
+import com.fin.spr.models.Category;
+import com.fin.spr.controllers.CategoryController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class CategoryControllerTest {
+
+    @InjectMocks
+    private CategoryController categoryController;
+
+    @Mock
+    private ICategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllCategories() {
+        // Данные для теста
+        Category category1 = new Category(1, "slug 1", "name ");
+        Category category2 = new Category(2, "slug 2", "name ");
+
+        when(categoryService.getAllCategories()).thenReturn(List.of(category1, category2));
+
+        ResponseEntity<List<Category>> response = categoryController.getAllCategories();
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).hasSize(2)
+                .containsExactly(category1, category2);
+    }
+
+    @Test
+    void testGetCategoryByIdFound() {
+        Category category = new Category(1, "slug 1", "name ");
+
+        when(categoryService.getCategoryById(1)).thenReturn(Optional.of(category));
+
+        ResponseEntity<Category> response = categoryController.getCategoryById(1);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(category);
+    }
+
+    @Test
+    void testGetCategoryByIdNotFound() {
+        when(categoryService.getCategoryById(1)).thenReturn(Optional.empty());
+
+        ResponseEntity<Category> response = categoryController.getCategoryById(1);
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+
+    @Test
+    void testCreateCategorySuccess() {
+        Category category = new Category(1, "slug 1", "name ");
+
+        doNothing().when(categoryService).createCategory(category);
+
+        ResponseEntity<Category> response = categoryController.createCategory(category);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(201);
+        assertThat(response.getBody()).isEqualTo(category);
+    }
+
+
+    @Test
+    void testCreateCategoryAlreadyExists() {
+        Category category = new Category(1, "slug 1", "name ");
+
+        doThrow(EntityAlreadyExistsException.class).when(categoryService).createCategory(category);
+
+        ResponseEntity<Category> response = categoryController.createCategory(category);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(409);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    void testUpdateCategorySuccess() {
+        Category updatedCategory = new Category(1, "slug 1", "name ");
+
+        when(categoryService.updateCategory(1, updatedCategory)).thenReturn(true);
+
+        ResponseEntity<Category> response = categoryController.updateCategory(1, updatedCategory);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(updatedCategory);
+    }
+
+    @Test
+    void testUpdateCategoryNotFound() {
+        Category updatedCategory = new Category(1, "slug 1", "name ");
+
+        when(categoryService.updateCategory(1, updatedCategory)).thenReturn(false);
+
+        ResponseEntity<Category> response = categoryController.updateCategory(1, updatedCategory);
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+
+    @Test
+    void testDeleteCategorySuccess() {
+        when(categoryService.deleteCategory(1)).thenReturn(true);
+
+        ResponseEntity<Void> response = categoryController.deleteCategory(1);
+        assertThat(response.getStatusCodeValue()).isEqualTo(204);
+    }
+
+    @Test
+    void testDeleteCategoryNotFound() {
+        when(categoryService.deleteCategory(1)).thenReturn(false);
+
+        ResponseEntity<Void> response = categoryController.deleteCategory(1);
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+}

--- a/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
+++ b/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
@@ -3,7 +3,6 @@ package com.fin.spr.controllers;
 import com.fin.spr.exceptions.EntityAlreadyExistsException;
 import com.fin.spr.interfaces.ICategoryService;
 import com.fin.spr.models.Category;
-import com.fin.spr.controllers.CategoryController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -11,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.ResponseEntity;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
+++ b/src/test/java/com/fin/spr/controllers/CategoryControllerTest.java
@@ -37,9 +37,8 @@ class CategoryControllerTest {
 
         when(categoryService.getAllCategories()).thenReturn(List.of(category1, category2));
 
-        ResponseEntity<List<Category>> response = categoryController.getAllCategories();
-        assertThat(response.getStatusCodeValue()).isEqualTo(200);
-        assertThat(response.getBody()).hasSize(2)
+        List<Category> response = categoryController.getAllCategories();
+        assertThat(response).hasSize(2)
                 .containsExactly(category1, category2);
     }
 

--- a/src/test/java/com/fin/spr/controllers/LocationControllerIntegrationTest.java
+++ b/src/test/java/com/fin/spr/controllers/LocationControllerIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.models.Location;
+import com.fin.spr.services.LocationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LocationControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LocationService locationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Location testLocation1;
+    private Location testLocation2;
+
+    private static final String BASE_URL = "/api/v1/locations";
+
+    @BeforeEach
+    public void setup() {
+        testLocation1 = new Location("paris", "Paris");
+        testLocation2 = new Location("london", "London");
+    }
+
+    @Test
+    public void testGetAllLocations() throws Exception {
+        Mockito.when(locationService.getAllLocations()).thenReturn(Arrays.asList(testLocation1, testLocation2));
+
+        mockMvc.perform(get(BASE_URL))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].name").value("Paris"))
+                .andExpect(jsonPath("$[1].name").value("London"));
+    }
+
+    @Test
+    public void testGetLocationBySlug_Success() throws Exception {
+        Mockito.when(locationService.getLocationBySlug("paris")).thenReturn(Optional.of(testLocation1));
+
+        mockMvc.perform(get(BASE_URL + "/paris"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value("Paris"))
+                .andExpect(jsonPath("$.slug").value("paris"));
+    }
+
+    @Test
+    public void testGetLocationBySlug_NotFound() throws Exception {
+        Mockito.when(locationService.getLocationBySlug("berlin")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(BASE_URL + "/berlin"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testCreateLocation_Success() throws Exception {
+        Mockito.doNothing().when(locationService).createLocation(any(Location.class));
+
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testLocation1)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Paris"))
+                .andExpect(jsonPath("$.slug").value("paris"));
+    }
+
+    @Test
+    public void testCreateLocation_Conflict() throws Exception {
+        Mockito.doThrow(new EntityAlreadyExistsException("Location already exists")).when(locationService).createLocation(any(Location.class));
+
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testLocation1)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    public void testUpdateLocation_Success() throws Exception {
+        Mockito.when(locationService.updateLocation(eq("paris"), any(Location.class))).thenReturn(true);
+
+        mockMvc.perform(put(BASE_URL + "/paris")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testLocation1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Paris"))
+                .andExpect(jsonPath("$.slug").value("paris"));
+    }
+
+    @Test
+    public void testUpdateLocation_NotFound() throws Exception {
+        Mockito.when(locationService.updateLocation(eq("berlin"), any(Location.class))).thenReturn(false);
+
+        mockMvc.perform(put(BASE_URL + "/berlin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testLocation1)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testDeleteLocation_Success() throws Exception {
+        Mockito.when(locationService.deleteLocation("paris")).thenReturn(true);
+
+        mockMvc.perform(delete(BASE_URL + "/paris"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void testDeleteLocation_NotFound() throws Exception {
+        Mockito.when(locationService.deleteLocation("berlin")).thenReturn(false);
+
+        mockMvc.perform(delete(BASE_URL + "/berlin"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/fin/spr/controllers/LocationControllerTest.java
+++ b/src/test/java/com/fin/spr/controllers/LocationControllerTest.java
@@ -1,0 +1,124 @@
+package com.fin.spr.controllers;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import com.fin.spr.interfaces.ILocationService;
+import com.fin.spr.models.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class LocationControllerTest {
+
+    @InjectMocks
+    private LocationController locationController;
+
+    @Mock
+    private ILocationService locationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllLocations() {
+        Location location1 = new Location("slug 1", "Location 1");
+        Location location2 = new Location("slug 2", "Location 2");
+
+        when(locationService.getAllLocations()).thenReturn(List.of(location1, location2));
+
+        ResponseEntity<List<Location>> response = locationController.getAllLocations();
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).hasSize(2)
+                .containsExactly(location1, location2);
+    }
+
+    @Test
+    void testGetLocationByIdFound() {
+        Location location = new Location("slug 1", "Location 1");
+
+        when(locationService.getLocationBySlug("slug 1")).thenReturn(Optional.of(location));
+
+        ResponseEntity<Location> response = locationController.getLocationBySlug("slug 1");
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(location);
+    }
+
+    @Test
+    void testGetLocationByIdNotFound() {
+        when(locationService.getLocationBySlug("slug 1")).thenReturn(Optional.empty());
+
+        ResponseEntity<Location> response = locationController.getLocationBySlug("slug 1");
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+
+    @Test
+    void testCreateLocationSuccess() {
+        Location location = new Location("slug 1", "Location 1");
+
+        doNothing().when(locationService).createLocation(location);
+
+        ResponseEntity<Location> response = locationController.createLocation(location);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(201);
+        assertThat(response.getBody()).isEqualTo(location);
+    }
+
+    @Test
+    void testCreateLocationAlreadyExists() {
+        Location location = new Location("slug 1", "Location 1");
+
+        doThrow(EntityAlreadyExistsException.class).when(locationService).createLocation(location);
+
+        ResponseEntity<Location> response = locationController.createLocation(location);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(409);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    void testUpdateLocationSuccess() {
+        Location updatedLocation = new Location("Updated slug", "Updated Location");
+
+        when(locationService.updateLocation("slug", updatedLocation)).thenReturn(true);
+
+        ResponseEntity<Location> response = locationController.updateLocation("slug", updatedLocation);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(updatedLocation);
+    }
+
+    @Test
+    void testUpdateLocationNotFound() {
+        Location updatedLocation = new Location("Updated slug", "Updated Location");
+
+        when(locationService.updateLocation("slug", updatedLocation)).thenReturn(false);
+
+        ResponseEntity<Location> response = locationController.updateLocation("slug", updatedLocation);
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+
+    @Test
+    void testDeleteLocationSuccess() {
+        when(locationService.deleteLocation("slug")).thenReturn(true);
+
+        ResponseEntity<Void> response = locationController.deleteLocation("slug");
+        assertThat(response.getStatusCodeValue()).isEqualTo(204);
+    }
+
+    @Test
+    void testDeleteLocationNotFound() {
+        when(locationService.deleteLocation("slug")).thenReturn(false);
+
+        ResponseEntity<Void> response = locationController.deleteLocation("slug");
+        assertThat(response.getStatusCodeValue()).isEqualTo(404);
+    }
+}

--- a/src/test/java/com/fin/spr/controllers/LocationControllerTest.java
+++ b/src/test/java/com/fin/spr/controllers/LocationControllerTest.java
@@ -36,9 +36,8 @@ class LocationControllerTest {
 
         when(locationService.getAllLocations()).thenReturn(List.of(location1, location2));
 
-        ResponseEntity<List<Location>> response = locationController.getAllLocations();
-        assertThat(response.getStatusCodeValue()).isEqualTo(200);
-        assertThat(response.getBody()).hasSize(2)
+        List<Location> response = locationController.getAllLocations();
+        assertThat(response).hasSize(2)
                 .containsExactly(location1, location2);
     }
 

--- a/src/test/java/com/fin/spr/services/CategoryServiceTest.java
+++ b/src/test/java/com/fin/spr/services/CategoryServiceTest.java
@@ -55,7 +55,7 @@ class CategoryServiceTest {
     void testCreateCategory() {
         Category category = new Category(1, "Slug 1", "Name 1");
 
-        categoryService.createCategory(1, category);
+        categoryService.createCategory(category);
 
         verify(categoryStorage, times(1)).create(1, category);
     }

--- a/src/test/java/com/fin/spr/services/CategoryServiceTest.java
+++ b/src/test/java/com/fin/spr/services/CategoryServiceTest.java
@@ -1,0 +1,95 @@
+package com.fin.spr.services;
+
+import com.fin.spr.models.Category;
+import com.fin.spr.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class CategoryServiceTest {
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Mock
+    private InMemoryStorage<Category, Integer> categoryStorage;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllCategories() {
+        Category category1 = new Category(1, "Slug 1", "Name 1");
+        Category category2 = new Category(2, "Slug 2", "Name 2");
+
+        when(categoryStorage.getAll()).thenReturn(List.of(category1, category2));
+
+        List<Category> categories = categoryService.getAllCategories();
+        assertThat(categories).hasSize(2)
+                .containsExactly(category1, category2);
+    }
+
+    @Test
+    void testGetCategoryById() {
+        Category category = new Category(1, "Slug 1", "Name 1");
+
+        when(categoryStorage.getById(1)).thenReturn(Optional.of(category));
+
+
+        Optional<Category> foundCategory = categoryService.getCategoryById(1);
+        assertThat(foundCategory).isPresent()
+                .hasValue(category);
+    }
+
+    @Test
+    void testCreateCategory() {
+        Category category = new Category(1, "Slug 1", "Name 1");
+
+        categoryService.createCategory(1, category);
+
+        verify(categoryStorage, times(1)).create(1, category);
+    }
+
+    @Test
+    void testUpdateCategory() {
+        Category category = new Category(1, "Slug 1", "Name 1");
+        Category updatedCategory = new Category(2, "Slug 2", "Name 2");
+
+        when(categoryStorage.update(1, updatedCategory)).thenReturn(true);
+
+        boolean result = categoryService.updateCategory(1, updatedCategory);
+
+        assertThat(result).isTrue();
+        verify(categoryStorage, times(1)).update(1, updatedCategory);
+    }
+
+    @Test
+    void testDeleteCategory() {
+        when(categoryStorage.delete(1)).thenReturn(true);
+
+        boolean result = categoryService.deleteCategory(1);
+
+        assertThat(result).isTrue();
+        verify(categoryStorage, times(1)).delete(1);
+    }
+
+    @Test
+    void testDeleteCategoryNotFound() {
+        when(categoryStorage.delete(2)).thenReturn(false);
+
+        boolean result = categoryService.deleteCategory(2);
+
+        assertThat(result).isFalse();
+        verify(categoryStorage, times(1)).delete(2);
+    }
+}

--- a/src/test/java/com/fin/spr/services/LocationServiceTest.java
+++ b/src/test/java/com/fin/spr/services/LocationServiceTest.java
@@ -1,0 +1,95 @@
+package com.fin.spr.services;
+
+import com.fin.spr.models.Location;
+import com.fin.spr.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class LocationServiceTest {
+
+    @InjectMocks
+    private LocationService locationService;
+
+    @Mock
+    private InMemoryStorage<Location, String> locationStorage;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllLocations() {
+        Location location1 = new Location("slug1", "Location 1");
+        Location location2 = new Location("slug2", "Location 2");
+
+        when(locationStorage.getAll()).thenReturn(List.of(location1, location2));
+
+        List<Location> locations = locationService.getAllLocations();
+        assertThat(locations).hasSize(2)
+                .containsExactly(location1, location2);
+    }
+
+    @Test
+    void testGetLocationBySlug() {
+        Location location = new Location("slug1", "Location 1");
+
+        when(locationStorage.getById("slug1")).thenReturn(Optional.of(location));
+
+        Optional<Location> foundLocation = locationService.getLocationBySlug("slug1");
+        assertThat(foundLocation).isPresent()
+                .hasValue(location);
+    }
+
+    @Test
+    void testCreateLocation() {
+        Location location = new Location("slug1", "Location 1");
+
+        locationService.createLocation(location);
+
+        verify(locationStorage, times(1)).create("slug1", location);
+    }
+
+    @Test
+    void testUpdateLocation() {
+        Location location = new Location("slug1", "Location 1");
+        Location updatedLocation = new Location("slug1", "Updated Location");
+
+        when(locationStorage.update("slug1", updatedLocation)).thenReturn(true);
+
+        boolean result = locationService.updateLocation("slug1", updatedLocation);
+
+        assertThat(result).isTrue();
+        verify(locationStorage, times(1)).update("slug1", updatedLocation);
+    }
+
+    @Test
+    void testDeleteLocation() {
+        when(locationStorage.delete("slug1")).thenReturn(true);
+
+        boolean result = locationService.deleteLocation("slug1");
+
+        assertThat(result).isTrue();
+        verify(locationStorage, times(1)).delete("slug1");
+    }
+
+    @Test
+    void testDeleteLocationNotFound() {
+        when(locationStorage.delete("slug2")).thenReturn(false);
+
+        boolean result = locationService.deleteLocation("slug2");
+
+        assertThat(result).isFalse();
+        verify(locationStorage, times(1)).delete("slug2");
+    }
+}

--- a/src/test/java/com/fin/spr/services/LocationServiceTest.java
+++ b/src/test/java/com/fin/spr/services/LocationServiceTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class LocationServiceTest {

--- a/src/test/java/com/fin/spr/storage/InMemoryStorageTest.java
+++ b/src/test/java/com/fin/spr/storage/InMemoryStorageTest.java
@@ -52,7 +52,6 @@ class InMemoryStorageTest {
 
     @Test
     void testDelete() {
-        // Проверка удаления
         storage.create(1, "Entity to be deleted");
 
         boolean deleted = storage.delete(1);

--- a/src/test/java/com/fin/spr/storage/InMemoryStorageTest.java
+++ b/src/test/java/com/fin/spr/storage/InMemoryStorageTest.java
@@ -1,0 +1,92 @@
+package com.fin.spr.storage;
+
+import com.fin.spr.exceptions.EntityAlreadyExistsException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InMemoryStorageTest {
+
+    private InMemoryStorage<String, Integer> storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new InMemoryStorage<>();
+    }
+
+    @Test
+    void testCreateAndGet() {
+        storage.create(1, "Test Entity");
+
+        assertThat(storage.getAll())
+                .hasSize(1);
+
+        assertThat(storage.getById(1))
+                .isPresent()
+                .hasValue("Test Entity");
+    }
+
+    @Test
+    void testGetAll() {
+        storage.create(1, "First Entity");
+        storage.create(2, "Second Entity");
+
+        assertThat(storage.getAll())
+                .hasSize(2)
+                .containsExactly("First Entity", "Second Entity");
+    }
+
+    @Test
+    void testUpdate() {
+        storage.create(1, "Initial Entity");
+        storage.update(1, "Updated Entity");
+
+        assertThat(storage.getById(1))
+                .isPresent()
+                .hasValue("Updated Entity");
+
+        assertThat(storage.getAll()).hasSize(1);
+    }
+
+    @Test
+    void testDelete() {
+        // Проверка удаления
+        storage.create(1, "Entity to be deleted");
+
+        boolean deleted = storage.delete(1);
+
+        assertThat(deleted).isTrue();
+        assertThat(storage.getById(1)).isNotPresent();
+
+        assertThat(storage.getAll()).isEmpty();
+    }
+
+    @Test
+    void testCreateAlreadyExists() {
+        storage.create(1, "Existing Entity");
+
+        assertThatThrownBy(() -> storage.create(1, "Another Entity"))
+                .isInstanceOf(EntityAlreadyExistsException.class)
+                .hasMessageContaining("Entity with ID 1 already exists.");
+
+        assertThat(storage.getAll()).hasSize(1);
+    }
+
+    @Test
+    void testUpdateNonExistentEntity() {
+        boolean updated = storage.update(1, "Non-existent Entity");
+
+        assertThat(updated).isFalse();
+        assertThat(storage.getAll()).isEmpty();
+    }
+
+    @Test
+    void testDeleteNonExistentEntity() {
+        boolean deleted = storage.delete(1);
+
+        assertThat(deleted).isFalse();
+        assertThat(storage.getAll()).isEmpty();
+    }
+}


### PR DESCRIPTION
# Описание

В этом PR реализованы два CRUD REST контроллера для работы с сущностями категорий и городов из сервиса [kudago.com](https://kudago.com). Реализованы следующие эндпоинты:

## Контроллер для категорий (Categories)

- **GET** `/api/v1/places/categories`  
  Получить все категории.  

- **GET** `/api/v1/places/categories/{id}`  
  Получить категорию по её ID.

- **POST** `/api/v1/places/categories`  
  Создать новую категорию.

- **PUT** `/api/v1/places/categories/{id}`  
  Обновить категорию по её ID.

- **DELETE** `/api/v1/places/categories/{id}`  
  Удалить категорию по её ID.

## Контроллер для городов (Locations)

- **GET** `/api/v1/locations`  
  Получить все города.  

- **GET** `/api/v1/locations/{slug}`  
  Получить город по его slug.

- **POST** `/api/v1/locations`  
  Создать новый город.

- **PUT** `/api/v1/locations/{slug}`  
  Обновить город по его slug.

- **DELETE** `/api/v1/locations/{slug}`  
  Удалить город по его slug.

# Хранение данных

Для хранения данных реализовано параметризованное хранилище, использующее `ConcurrentHashMap`. 

# Инициализация данных

При старте приложения выполняется опрос API KudaGo для инициализации источников данных. Этапы инициализации, заполнения и завершения процесса логируются для обеспечения прозрачности.

# Логирование времени выполнения

Реализована аннотация, применимая к методам и классам, для логирования времени их выполнения. Если аннотация применяется к классу, все его методы будут логироваться.

## Применение аннотации

- Аннотация применяется к методу инициализации хранилища.
- Аннотация также применена к классам контроллеров.

# Проверка

- Хранилище данных, все контроллеры и сервисы протестированы с использованием юнит-тестов.
- Логирование корректно работает для методов с примененной аннотацией.